### PR TITLE
Update cli.eval to have the same YAML format as other cli files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ plot_single(
 )
 ```
 
+## 📔 Jupyter Notebook Examples
+See the [example folder](example) for more examples on common tasks, e.g. visualizing forecasts, predicting from pandas DataFrame, etc.
+
 ## 💻 Command Line Interface
 We provide several scripts which act as a [command line interface](cli) to easily run fine-tuning, evaluation, and even pre-training jobs. 
 [Configurations](cli/conf) are managed with the [Hydra](https://hydra.cc/) framework.
@@ -175,10 +178,11 @@ The evaluation script can be used to calculate evaluation metrics such as MSE, M
 Following up on the fine-tuning example, we can now perform evaluation on the test split by running the following script:
 ```shell
 python -m cli.eval \ 
-  data=etth1_test \ 
-  patch_size=32 \ 
-  context_length=1000 \ 
-  checkpoint_path=moirai_1.0_R_small
+  run_name=example_eval \
+  model=moirai_1.0_R_small \
+  model.patch_size=32 \ 
+  model.context_length=1000 \
+  data=etth1_test
 ```
 
 Alternatively, we provide access to popular datasets, and can be toggled via the [data configurations](cli/conf/eval/data).
@@ -192,12 +196,13 @@ echo "LSF_PATH=PATH_TO_TSLIB/dataset" >> .env
 Thereafter, simply run the following script with the predefined [Hydra config file](cli/conf/eval/data/lsf_test.yaml):
 ```shell
 python -m cli.eval \ 
+  run_name=example_eval \
+  model=moirai_1.0_R_small \
+  model.patch_size=32 \ 
+  model.context_length=1000 \ 
   data=lsf_test \
   data.dataset_name=ETTh1 \
-  data.prediction_length=96 \ 
-  patch_size=32 \ 
-  context_length=1000 \ 
-  checkpoint_path=moirai_1.0_R_small
+  data.prediction_length=96 
 ```
 
 ### Pre-training
@@ -217,9 +222,6 @@ python -m cli.pretrain \
   model=moirai_small \
   data=lotsa_v1_unweighted
 ```
-
-## 📔 Jupyter Notebook Examples
-See the [example folder](example) for more examples on common tasks, e.g. visualizing forecasts, predicting from pandas DataFrame, etc.
 
 ## 👀 Citing Uni2TS
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The evaluation script can be used to calculate evaluation metrics such as MSE, M
 Following up on the fine-tuning example, we can now perform evaluation on the test split by running the following script:
 ```shell
 python -m cli.eval \ 
-  run_name=example_eval \
+  run_name=example_eval_1 \
   model=moirai_1.0_R_small \
   model.patch_size=32 \ 
   model.context_length=1000 \
@@ -196,7 +196,7 @@ echo "LSF_PATH=PATH_TO_TSLIB/dataset" >> .env
 Thereafter, simply run the following script with the predefined [Hydra config file](cli/conf/eval/data/lsf_test.yaml):
 ```shell
 python -m cli.eval \ 
-  run_name=example_eval \
+  run_name=example_eval_2 \
   model=moirai_1.0_R_small \
   model.patch_size=32 \ 
   model.context_length=1000 \ 

--- a/cli/conf/eval/checkpoint_path/moirai_1.0_R_base.yaml
+++ b/cli/conf/eval/checkpoint_path/moirai_1.0_R_base.yaml
@@ -1,3 +1,0 @@
-_target_: huggingface_hub.hf_hub_download
-repo_id: Salesforce/moirai-1.0-R-base
-filename: model.ckpt

--- a/cli/conf/eval/checkpoint_path/moirai_1.0_R_large.yaml
+++ b/cli/conf/eval/checkpoint_path/moirai_1.0_R_large.yaml
@@ -1,3 +1,0 @@
-_target_: huggingface_hub.hf_hub_download
-repo_id: Salesforce/moirai-1.0-R-large
-filename: model.ckpt

--- a/cli/conf/eval/checkpoint_path/moirai_1.0_R_small.yaml
+++ b/cli/conf/eval/checkpoint_path/moirai_1.0_R_small.yaml
@@ -1,3 +1,0 @@
-_target_: huggingface_hub.hf_hub_download
-repo_id: Salesforce/moirai-1.0-R-small
-filename: model.ckpt

--- a/cli/conf/eval/default.yaml
+++ b/cli/conf/eval/default.yaml
@@ -1,16 +1,11 @@
 hydra:
   run:
-    dir: outputs/${hydra:job.name}/${hydra:runtime.choices.data}/${data.dataset_name}/${data.mode}/prediction_length=${data.prediction_length}
+    dir: outputs/${hydra:job.name}/${hydra:runtime.choices.data}/${data.dataset_name}/${data.mode}/prediction_length=${data.prediction_length}/${run_name}
 defaults:
+  - model: ???
   - data: ???
-  - checkpoint_path: ???
   - _self_
-patch_size: ???
-context_length: ???
-load_from_checkpoint:
-  _target_: uni2ts.model.moirai.MoiraiForecast.load_from_checkpoint
-  _partial_: true
-  num_samples: 100
+run_name: ???
 metrics:
   - _target_: gluonts.ev.metrics.MSE
   - _target_: uni2ts.eval_util.metrics.MedianMSE

--- a/cli/conf/eval/model/moirai_1.0_R_base.yaml
+++ b/cli/conf/eval/model/moirai_1.0_R_base.yaml
@@ -1,0 +1,8 @@
+_target_: uni2ts.model.moirai.MoiraiForecast.load_from_checkpoint
+checkpoint_path:
+  _target_: huggingface_hub.hf_hub_download
+  repo_id: Salesforce/moirai-1.0-R-base
+  filename: model.ckpt
+num_samples: 100
+patch_size: ???
+context_length: ???

--- a/cli/conf/eval/model/moirai_1.0_R_large.yaml
+++ b/cli/conf/eval/model/moirai_1.0_R_large.yaml
@@ -1,0 +1,8 @@
+_target_: uni2ts.model.moirai.MoiraiForecast.load_from_checkpoint
+checkpoint_path:
+  _target_: huggingface_hub.hf_hub_download
+  repo_id: Salesforce/moirai-1.0-R-large
+  filename: model.ckpt
+num_samples: 100
+patch_size: ???
+context_length: ???

--- a/cli/conf/eval/model/moirai_1.0_R_small.yaml
+++ b/cli/conf/eval/model/moirai_1.0_R_small.yaml
@@ -1,0 +1,8 @@
+_target_: uni2ts.model.moirai.MoiraiForecast.load_from_checkpoint
+checkpoint_path:
+  _target_: huggingface_hub.hf_hub_download
+  repo_id: Salesforce/moirai-1.0-R-small
+  filename: model.ckpt
+num_samples: 100
+patch_size: ???
+context_length: ???

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "torch>=2.0",
+  "torch>=2.1",
   "lightning>=2.0",
   "gluonts~=0.14.3",
   "numpy~=1.26.0",


### PR DESCRIPTION
1. cli/conf/eval/default.yaml now follows a similar format to pretrain and finetune
2. move `patch_size` and `context_length` parameters to the model specification to generalise the script - patch_size was a model specific parameter, move those to the model config file