### PR TITLE
change ValueError to warning when .env file is missing

### DIFF
--- a/src/uni2ts/common/env.py
+++ b/src/uni2ts/common/env.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import os
+import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -39,7 +40,7 @@ class Env:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             if not load_dotenv():
-                raise ValueError("Failed to load .env file")
+                warnings.warn("Failed to load .env file.")
             cls.monkey_patch_path_vars()
         return cls._instance
 


### PR DESCRIPTION
The .env file is not always necessary, especially when loading datasets from GluonTS, but a ValueError is always raised. This PR fixes this issue by changing it to a warning - when attempting to access the environment variables later, it will return None.