### PR TITLE
Bug fix: MultiOutSizeLinear masks outputs to 0 when dimension of  parameter >1 and dim * patch_size is not present in out_feat_size.

### DIFF
--- a/src/uni2ts/distribution/_base.py
+++ b/src/uni2ts/distribution/_base.py
@@ -79,7 +79,7 @@ class DistrParamProj(nn.Module):
                     else proj_layer(
                         in_features,
                         tuple(dim * of for of in out_features),
-                        dim,
+                        dim=dim,
                         **kwargs,
                     )
                 ),
@@ -165,7 +165,7 @@ class DistributionOutput:
         self,
         in_features: int,
         out_features: int | tuple[int, ...] | list[int],
-        proj_layer: type[nn.Module] = MultiOutSizeLinear,
+        proj_layer: Callable[..., nn.Module] = MultiOutSizeLinear,
         **kwargs: Any,
     ) -> nn.Module:
         return DistrParamProj(

--- a/src/uni2ts/distribution/_base.py
+++ b/src/uni2ts/distribution/_base.py
@@ -77,7 +77,10 @@ class DistrParamProj(nn.Module):
                     proj_layer(in_features, dim * out_features, **kwargs)
                     if isinstance(out_features, int)
                     else proj_layer(
-                        in_features, tuple(dim * of for of in out_features), **kwargs
+                        in_features,
+                        tuple(dim * of for of in out_features),
+                        dim,
+                        **kwargs,
                     )
                 ),
                 args_dim,

--- a/src/uni2ts/module/ts_embed.py
+++ b/src/uni2ts/module/ts_embed.py
@@ -115,12 +115,14 @@ class MultiOutSizeLinear(nn.Module):
         self,
         in_features: int,
         out_features_ls: tuple[int, ...],
+        dim: int,
         bias: bool = True,
         dtype: Optional[torch.dtype] = None,
     ):
         super().__init__()
         self.in_features = in_features
         self.out_features_ls = out_features_ls
+        self.dim = dim
 
         self.weight = nn.Parameter(
             torch.empty(
@@ -173,7 +175,7 @@ class MultiOutSizeLinear(nn.Module):
             weight = self.weight[idx] * self.mask[idx]
             bias = self.bias[idx] if self.bias is not None else 0
             out = out + (
-                torch.eq(out_feat_size, feat_size).unsqueeze(-1)
+                torch.eq(out_feat_size, feat_size // self.dim).unsqueeze(-1)
                 * (einsum(weight, x, "out inp, ... inp -> ... out") + bias)
             )
         return out

--- a/src/uni2ts/module/ts_embed.py
+++ b/src/uni2ts/module/ts_embed.py
@@ -115,7 +115,7 @@ class MultiOutSizeLinear(nn.Module):
         self,
         in_features: int,
         out_features_ls: tuple[int, ...],
-        dim: int,
+        dim: int = 1,
         bias: bool = True,
         dtype: Optional[torch.dtype] = None,
     ):

--- a/test/distribution/test_base.py
+++ b/test/distribution/test_base.py
@@ -1,0 +1,134 @@
+#  Copyright (c) 2024, Salesforce, Inc.
+#  SPDX-License-Identifier: Apache-2
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+from einops import einsum, rearrange
+from jaxtyping import PyTree
+from torch.utils._pytree import tree_flatten, tree_map
+
+from uni2ts.distribution import DistrParamProj
+from uni2ts.distribution._base import convert_to_container, tree_map_multi
+from uni2ts.module.ts_embed import MultiOutSizeLinear
+
+
+@pytest.mark.parametrize(
+    "out_features",
+    [
+        (1,),
+        [1],
+        (8,),
+        [8],
+        (8, 16, 32),
+        [8, 16, 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "args_dim",
+    [
+        {"loc": 1, "scale": 1, "df": 1},
+        {"loc": 2, "scale": 1, "df": 1},
+        {"weights_logit": 2, "components": [{"loc1": 1}, {"loc2": 1, "scale2": 1}]},
+        {
+            "weights_logit": 4,
+            "components": [
+                {"loc1": 1},
+                {"loc2": 1},
+                {"loc3": 1},
+                {"loc4": 1, "scale4": 1},
+            ],
+        },
+    ],
+)
+@pytest.mark.parametrize("batch_shape", [tuple(), (100,), (100, 10)])
+def test_multi_out_size_linear_proj(
+    out_features: tuple[int, ...] | list[int],
+    args_dim: PyTree[int],
+    batch_shape: tuple[int, ...],
+    in_features: int = 32,
+):
+    out_proj = DistrParamProj(
+        in_features=in_features,
+        out_features=out_features,
+        args_dim=args_dim,
+        domain_map=tree_map(lambda x: lambda y: y, args_dim),
+        proj_layer=MultiOutSizeLinear,
+    )
+
+    x = torch.randn(*batch_shape, in_features)
+    out_feat_size = torch.as_tensor(np.random.choice(out_features, batch_shape))
+    out = out_proj(x, out_feat_size)
+
+    for feat_size in out_features:
+        feat_size_x = x[out_feat_size == feat_size]
+
+        def check_shape(out_leaf: torch.Tensor, proj: MultiOutSizeLinear) -> bool:
+            feat_size_out = out_leaf[out_feat_size == feat_size]
+            try:
+                feat_size_weight = proj.weight[
+                    proj.out_features_ls.index(feat_size * proj.dim)
+                ]
+            except ValueError as e:
+                print(proj.out_features_ls, feat_size, proj.dim, feat_size * proj.dim)
+                raise e
+            feat_size_bias = (
+                proj.bias[proj.out_features_ls.index(feat_size * proj.dim)]
+                if proj.bias is not None
+                else 0
+            )
+            feat_size_gt = rearrange(
+                einsum(feat_size_weight, feat_size_x, "out inp, ... inp -> ... out")
+                + feat_size_bias,
+                "... (dim out_size) -> ... out_size dim",
+                out_size=max(out_features),
+            )
+            return feat_size_gt.shape == feat_size_out.shape
+
+        def check_all_close(out_leaf: torch.Tensor, proj: MultiOutSizeLinear) -> bool:
+            feat_size_out = out_leaf[out_feat_size == feat_size]
+            try:
+                feat_size_weight = proj.weight[
+                    proj.out_features_ls.index(feat_size * proj.dim)
+                ]
+            except ValueError as e:
+                print(proj.out_features_ls, feat_size, proj.dim, feat_size * proj.dim)
+                raise e
+            feat_size_bias = (
+                proj.bias[proj.out_features_ls.index(feat_size * proj.dim)]
+                if proj.bias is not None
+                else 0
+            )
+            feat_size_gt = rearrange(
+                einsum(feat_size_weight, feat_size_x, "out inp, ... inp -> ... out")
+                + feat_size_bias,
+                "... (dim out_size) -> ... out_size dim",
+                out_size=max(out_features),
+            )
+            return torch.allclose(feat_size_gt, feat_size_out, atol=1e-6)
+
+        assert all(
+            tree_flatten(
+                tree_map_multi(check_shape, out, convert_to_container(out_proj.proj))
+            )[0]
+        )
+
+        assert all(
+            tree_flatten(
+                tree_map_multi(
+                    check_all_close, out, convert_to_container(out_proj.proj)
+                )
+            )[0]
+        )

--- a/test/module/test_ts_embed.py
+++ b/test/module/test_ts_embed.py
@@ -96,13 +96,22 @@ def test_multi_in_size_linear(
 
 @pytest.mark.parametrize("batch_shape", [tuple(), (1,), (10, 3)])
 @pytest.mark.parametrize("in_features", [64, 128, 512])
-@pytest.mark.parametrize("out_features_ls", [(10,), (10, 20, 30)])
+@pytest.mark.parametrize(
+    "out_features_ls, dim",
+    [
+        ((10,), 1),
+        ((20,), 2),
+        ((10, 20, 30), 1),
+        ((20, 40, 60), 2),
+    ],
+)
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize("seed", [0, 1, 2])
 def test_multi_out_size_linear(
     batch_shape: tuple[int, ...],
     in_features: int,
     out_features_ls: tuple[int, ...],
+    dim: int,
     bias: bool,
     seed: int,
 ):
@@ -117,9 +126,10 @@ def test_multi_out_size_linear(
     embed = MultiOutSizeLinear(
         in_features,
         out_features_ls,
+        dim,
         bias=bias,
     )
-    embed_out = embed(x, inp_ofs)
+    embed_out = embed(x, inp_ofs // dim)
 
     # init ground truth model
     torch.manual_seed(seed)

--- a/test/module/test_ts_embed.py
+++ b/test/module/test_ts_embed.py
@@ -126,7 +126,7 @@ def test_multi_out_size_linear(
     embed = MultiOutSizeLinear(
         in_features,
         out_features_ls,
-        dim,
+        dim=dim,
         bias=bias,
     )
     embed_out = embed(x, inp_ofs // dim)


### PR DESCRIPTION
This PR fixes a major bug for the `MultiOutSizeLinear` class.

When `dim > 1` in the following code snippet,
https://github.com/SalesforceAIResearch/uni2ts/blob/c4d75a3053c14e27ac4d875d7b31987abc1090a1/src/uni2ts/distribution/_base.py#L74-L85
it causes `for feat_size in self.out_features_ls` be `dim * patch_size`, whereas `out_feat_size` contains the patch sizes. This means that certain patch sizes could be ignored.
https://github.com/SalesforceAIResearch/uni2ts/blob/c4d75a3053c14e27ac4d875d7b31987abc1090a1/src/uni2ts/module/ts_embed.py#L172-L178

For the current configuration, this means that outputs with patch sizes 8 and 16 are always masked to 0.

Closes #44