### PR TITLE
Change to python3 for black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.2.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
The previous language version in https://github.com/SalesforceAIResearch/uni2ts/blob/main/.pre-commit-config.yaml is python3.10. When we use python3.11, it would throw an error. So, I relaxed to python3 as suggested in https://github.com/pre-commit/pre-commit/issues/1761#issuecomment-763028818.