### PR TITLE
change the version name and the project name for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "salesforce-uni2ts"
+name = "uni2ts"
 dynamic = [
   "version",
 ]
@@ -35,7 +35,8 @@ authors = [
   {name = "Doyen Sahoo"},
 ]
 maintainers = [
-  {name = "Gerald Woo", email = "gwoo@salesforce.com"}
+  {name = "Gerald Woo", email = "gwoo@salesforce.com"},
+  {name = "Juncheng Liu", email = "juncheng.liu@salesforce.com"}
 ]
 description = "Unified Training of Universal Time Series Forecasting Transformers"
 readme = "README.md"

--- a/src/uni2ts/__about__.py
+++ b/src/uni2ts/__about__.py
@@ -13,4 +13,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.0.0a0"
+__version__ = "1.1.0"


### PR DESCRIPTION
As pyproject.toml uses dynamic version name, I change the version name here in order to make pypi package with the correct version name