### PR TITLE
Moirai Agent: Update Chronos-2 model path

### DIFF
--- a/project/moirai-agent/gift_eval/tsf_models.py
+++ b/project/moirai-agent/gift_eval/tsf_models.py
@@ -31,7 +31,7 @@ def get_chronos_forecast_fn(device="cuda"):
     from chronos import Chronos2Pipeline
 
     pipeline = Chronos2Pipeline.from_pretrained(
-        "s3://autogluon/chronos-2", device_map=device, dtype=torch.float32
+        "amazon/chronos-2", device_map=device, dtype=torch.float32
     )
     quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 


### PR DESCRIPTION
Updated Chronos-2 model path in Moirai Agent. The model is on HF now and we plan to remove access to `s3://autogluon/chronos-2` soon. 