### PR TITLE
relax hydra-core pin from ==1.3 to >=1.3,<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "einops==0.7.*",
   "jaxtyping~=0.2.24",
   "python-dotenv==1.0.0",
-  "hydra-core==1.3",
+  "hydra-core>=1.3,<2",
   "orjson",
   "tensorboard",
   "multiprocess",


### PR DESCRIPTION
## Summary

- Changes `hydra-core==1.3` → `hydra-core>=1.3,<2` in `pyproject.toml`

## Why

The exact `==1.3` pin makes uni2ts incompatible with any package that requires `hydra-core>=1.3.1` or `>=1.3.2`. A concrete example: [`sam2`](https://github.com/facebookresearch/sam2) (Meta's Segment Anything Model 2) requires `hydra-core>=1.3.2`, so the two packages cannot be installed in the same environment today.

The 1.3.x series has only patch releases between 1.3.0 and 1.3.2. There are no breaking changes in those patches — they're bug fixes and minor improvements to the Hydra config system. Nothing in uni2ts should be affected.

## What was changed

```diff
-  "hydra-core==1.3",
+  "hydra-core>=1.3,<2",
```

The `<2` upper bound is conservative — it prevents any hypothetical `hydra-core 2.0` from being pulled in before this project has been tested against it.

## Test plan

- [ ] Verify existing tests still pass with `hydra-core==1.3.2` installed
- [ ] Confirm `pip install uni2ts sam2` resolves without conflict after this change