### PR TITLE
docs: clarify Moirai 2 multivariate tutorial support

### DIFF
--- a/example/moirai_forecast_pandas.ipynb
+++ b/example/moirai_forecast_pandas.ipynb
@@ -26,7 +26,7 @@
     "from uni2ts.model.moirai_moe import MoiraiMoEForecast, MoiraiMoEModule\n",
     "from uni2ts.model.moirai2 import Moirai2Forecast, Moirai2Module\n",
     "\n",
-    "MODEL = \"moirai2\"  # model name: choose from {'moirai', 'moirai-moe', 'moirai2'}"
+    "MODEL = \"moirai\"  # model name: choose from {'moirai', 'moirai-moe', 'moirai2'}"
    ]
   },
   {
@@ -909,7 +909,9 @@
     }
    },
    "source": [
-    "# 2.3 Multivariate Forecasting"
+    "# 2.3 Multivariate Forecasting\n",
+    "\n",
+    "Moirai 2 does not currently support multivariate forecasting. Use `moirai` or `moirai-moe` for this section."
    ]
   },
   {


### PR DESCRIPTION
Title: docs: clarify Moirai 2 multivariate tutorial support

## Summary

- Default the pandas tutorial to Moirai so it runs through the multivariate example.
- Document that Moirai 2 does not currently support multivariate forecasting and direct users to Moirai or Moirai-MoE.
- Checked the issue snapshot for assignment and duplicate-work signals; it is unassigned and no related PR is recorded.

## Test evidence

- `python3 -c "import json; n=json.load(open('example/moirai_forecast_pandas.ipynb')); s=''.join(''.join(c.get('source', [])) for c in n['cells']); assert 'MODEL = \"moirai\"' in s; assert 'Moirai 2 does not currently support multivariate forecasting.' in s; print('notebook guidance verified')"` — verified notebook JSON, the supported default, and the multivariate guidance.
- `git diff --check` — passed.

## Risks or notes for maintainers

- This is documentation/tutorial guidance only; it does not add Moirai 2 multivariate support.
- Full notebook execution was not run because it requires remote data and pretrained model downloads.
- Salesforce CLA completion and any code-owner review remain required before merge.

Refs #238
